### PR TITLE
Enabling WiFi Direct on android_ia.

### DIFF
--- a/wlan/iwlwifi/wpa_supplicant_overlay.conf
+++ b/wlan/iwlwifi/wpa_supplicant_overlay.conf
@@ -1,0 +1,6 @@
+ctrl_interface=wlan0
+disable_scan_offload=1
+wowlan_triggers=any
+pmf=1
+sched_scan_plans=30:10 300
+


### PR DESCRIPTION
Jira: https://01.org/jira/browse/AIA-152

Test: WiFi Direct should be enabled and available peers displayed.
Successful connection between the peers when prompted.

Signed-off-by: amrita.raju@intel.com

 Changes to be committed:
	new file:   iwlwifi/wpa_supplicant_overlay.conf

@kalyankondapally 
@Kishore409 
