### PR TITLE
Add the updater_ab_esp, used for update kernelflinger.efi.

### DIFF
--- a/recovery/updater_ab_esp/Android.mk
+++ b/recovery/updater_ab_esp/Android.mk
@@ -1,0 +1,10 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE:= updater_ab_esp
+LOCAL_MODULE_TAGS := optional
+LOCAL_SRC_FILES := updater_ab_esp.cpp
+LOCAL_MODULE_OWNER := intel
+LOCAL_MODULE_PATH  := $(TARGET_OUT_VENDOR)/bin
+LOCAL_FORCE_STATIC_EXECUTABLE := true
+include $(BUILD_EXECUTABLE)

--- a/recovery/updater_ab_esp/updater_ab_esp.cpp
+++ b/recovery/updater_ab_esp/updater_ab_esp.cpp
@@ -1,0 +1,10 @@
+
+#include <stdio.h>
+
+int main(int argc, char** argv)
+{
+	printf("This tool is used for update the kernelflinger.efi\n");
+
+	return 0;
+}
+


### PR DESCRIPTION
It will be called in postinstall stage in OTA update with A/B slot.
Currently the code just print the tool info.

Jira: None.
Test: Test it in KBL NUC.

Signed-off-by: Ming Tan <ming.tan@intel.com>
Signed-off-by: Zhou, Lihua <lihuax.zhou@intel.com>